### PR TITLE
Use build_pages.sh, remove go_build.sh

### DIFF
--- a/.github/workflows/go_build.yml
+++ b/.github/workflows/go_build.yml
@@ -22,7 +22,7 @@ jobs:
         run: |
           go build -o go-markdown-to-html cmd/main.go
           mkdir -p dist
-          ./bin/go_build.sh
+          ./bin/build_pages.sh
           zip -r artifact dist/
       - name: Create Release
         id: create_release

--- a/bin/go_build.sh
+++ b/bin/go_build.sh
@@ -1,9 +1,0 @@
-#!/usr/bin/env bash
-
-# go_build.sh
-
-function go_build () {
-  go build -o go-markdown-to-html cmd/main.go
-}
-
-go_build


### PR DESCRIPTION
I was testing with go_build.sh and committed it accidentally.
Let's use build_pages.sh in our workflow.