### PR TITLE
Fix HTML generation from double html tags

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -85,7 +85,6 @@ func writeBlog() {
 	var relativePath = relativePath(os.Args[4])
 	var content = readFile(os.Args[1])
 	htmlContent := string(MarkdownToHTML(content))
-	htmlContent = string(UpdateHtmlImgTags([]byte(htmlContent)))
 
 	var image string
 	if extracted := extractFirstImage(htmlContent); extracted != "" {
@@ -110,9 +109,10 @@ func writeBlog() {
 	var contentStr bytes.Buffer
 	contentTpl := template.Must(template.ParseFiles("bootstrap/clean-blog/content.html.tpl"))
 	contentTpl.Execute(&contentStr, body)
+	updatedContent := string(UpdateHtmlImgTags(contentStr.Bytes()))
 
 	outputStr.WriteString(headerStr.String())
-	outputStr.WriteString(contentStr.String())
+	outputStr.WriteString(updatedContent)
 	outputStr.WriteString(footerStr.String())
 
 	out, err := os.Create(os.Args[4])

--- a/cmd/update_html_img_tags.go
+++ b/cmd/update_html_img_tags.go
@@ -5,21 +5,24 @@ import (
 	"strings"
 
 	"golang.org/x/net/html"
+	"golang.org/x/net/html/atom"
 )
 
 func UpdateHtmlImgTags(content []byte) []byte {
 	reader := bytes.NewReader(content)
+	context := &html.Node{Type: html.ElementNode, Data: "body", DataAtom: atom.Body}
 
-	doc, err := html.Parse(reader)
+	nodes, err := html.ParseFragment(reader, context)
 	if err != nil {
 		panic(err)
 	}
 
-	UpdateHtmlImgNodes(doc)
-
 	var buf bytes.Buffer
-	if err := html.Render(&buf, doc); err != nil {
-		panic(err)
+	for _, n := range nodes {
+		UpdateHtmlImgNodes(n)
+		if err := html.Render(&buf, n); err != nil {
+			panic(err)
+		}
 	}
 
 	return buf.Bytes()

--- a/cmd/update_html_img_tags_test.go
+++ b/cmd/update_html_img_tags_test.go
@@ -52,3 +52,22 @@ func TestUpdateHtmlImgTags(t *testing.T) {
 		})
 	}
 }
+
+// UpdateHtmlImgTags is called on inner fragments (e.g. content.html.tpl's
+// <div>-wrapped output, which itself sits inside <body> opened by
+// header.html.tpl and closed by footer.html.tpl). It must not synthesize a
+// document wrapper around the fragment, or the assembled page would end up
+// with an <html>/<head>/<body> injected in the middle of the document.
+func TestUpdateHtmlImgTagsDoesNotWrapFragment(t *testing.T) {
+	input := `<div class="container"><div class="row"><div class="col-lg-8 col-md-10 mx-auto"><p>Hello</p><img src="x.jpg"></div></div></div>`
+	got := string(UpdateHtmlImgTags([]byte(input)))
+
+	for _, tag := range []string{"<html", "<head", "<body"} {
+		if strings.Contains(got, tag) {
+			t.Errorf("UpdateHtmlImgTags() = %q, unexpectedly contains %q wrapper", got, tag)
+		}
+	}
+	if !strings.Contains(got, `class="img-fluid"`) {
+		t.Errorf("UpdateHtmlImgTags() = %q, want img-fluid class applied", got)
+	}
+}


### PR DESCRIPTION
 - use `html.ParseFragment` so we do not nest `<html>` tags in the content template