### PR TITLE
Fix the post order for 2026 blogs

### DIFF
--- a/2026.json
+++ b/2026.json
@@ -1,12 +1,12 @@
 {
     "posts": [
         {
-            "title": "Tradeoffs in Engineering",
-            "url": "/2026/07/29/tradeoffs-in-engineering.html"
-        },
-        {
             "title": "The High Cost of Fire-and-Forget",
             "url": "/2026/08/18/high-cost-of-fire-and-forget.html"
+        },
+        {
+            "title": "Tradeoffs in Engineering",
+            "url": "/2026/07/29/tradeoffs-in-engineering.html"
         }
     ]
 }


### PR DESCRIPTION
 - the order of the `posts` array should be newest to oldest